### PR TITLE
Add matcher

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Matcher interface {
-	isMatch(value interface{}) bool
+	IsMatch(value interface{}) bool
 }
 
 type node struct {
@@ -211,7 +211,7 @@ func (n *node) splitCommonPrefix(existingNodeIndex int, path string) (*node, int
 func (n *node) search(path string, m Matcher) (found *node, params []string) {
 	pathLen := len(path)
 	if pathLen == 0 {
-		if n.leafValue == nil || (m != nil && !m.isMatch(n.leafValue)) {
+		if n.leafValue == nil || (m != nil && !m.IsMatch(n.leafValue)) {
 			return nil, nil
 		} else {
 			return n, nil

--- a/tree.go
+++ b/tree.go
@@ -17,6 +17,20 @@ type Matcher interface {
 	Match(value interface{}) bool
 }
 
+type trueMatcher struct {
+
+}
+
+func (m *trueMatcher) Match(value interface{}) bool {
+	return true
+}
+
+var tm *trueMatcher
+
+func init() {
+	tm = &trueMatcher{}
+}
+
 type node struct {
 	path string
 
@@ -211,11 +225,11 @@ func (n *node) splitCommonPrefix(existingNodeIndex int, path string) (*node, int
 func (n *node) search(path string, m Matcher) (found *node, params []string) {
 	pathLen := len(path)
 	if pathLen == 0 {
-		if n.leafValue == nil || (m != nil && !m.Match(n.leafValue)) {
+		if n.leafValue == nil || !m.Match(n.leafValue) {
 			return nil, nil
-		} else {
-			return n, nil
 		}
+
+		return n, nil
 	}
 
 	// First see if this matches a static token.
@@ -300,7 +314,15 @@ func (t *Tree) Add(path string, value interface{}) error {
 // Find a value in the tree associated to a path. If the found path
 // definition contains wildcards, the names and values of the wildcards
 // are returned in the second argument.
-func (t *Tree) Lookup(path string, m Matcher) (interface{}, map[string]string) {
+func (t *Tree) Lookup(path string) (interface{}, map[string]string) {
+	return t.LookupMatcher(path, tm)
+}
+
+// Find a value in the tree associated to a path. If the found path
+// definition contains wildcards, the names and values of the wildcards
+// are returned in the second argument. When value will be founded, matcher will be called to check if value
+// match extra logic.
+func (t *Tree) LookupMatcher (path string, m Matcher) (interface{}, map[string]string) {
 	if path == "" {
 		path = "/"
 	}

--- a/tree.go
+++ b/tree.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 )
 
+// When using the LookupMatch function, types satifying the Matcher interface can be used for additional checks and
+// to override the default result in case of path matches. The argument passed to the Match function is the original
+// value passed to the Tree.Add function.
 type Matcher interface {
 	Match(value interface{}) (bool, interface{})
 }
@@ -335,6 +338,9 @@ func (t *Tree) Lookup(path string) (interface{}, map[string]string) {
 // definition contains wildcards, the names and values of the wildcards
 // are returned in the second argument. When value will be founded, matcher will be called to check if value
 // match extra logic.
+// When a path match is found, the Matcher is called for additional, custom check. If it returns true, then
+// the additional returned value is used as the result of the lookup. If it returns false, the tree search continues
+// as if there was no path match in the given position at all.
 func (t *Tree) LookupMatcher (path string, m Matcher) (interface{}, map[string]string, interface{}) {
 	if path == "" {
 		path = "/"

--- a/tree.go
+++ b/tree.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Matcher interface {
-	IsMatch(value interface{}) bool
+	Match(value interface{}) bool
 }
 
 type node struct {
@@ -211,7 +211,7 @@ func (n *node) splitCommonPrefix(existingNodeIndex int, path string) (*node, int
 func (n *node) search(path string, m Matcher) (found *node, params []string) {
 	pathLen := len(path)
 	if pathLen == 0 {
-		if n.leafValue == nil || (m != nil && !m.IsMatch(n.leafValue)) {
+		if n.leafValue == nil || (m != nil && !m.Match(n.leafValue)) {
 			return nil, nil
 		} else {
 			return n, nil

--- a/tree.go
+++ b/tree.go
@@ -17,9 +17,7 @@ type Matcher interface {
 	Match(value interface{}) bool
 }
 
-type trueMatcher struct {
-
-}
+type trueMatcher struct {}
 
 func (m *trueMatcher) Match(value interface{}) bool {
 	return true

--- a/tree_test.go
+++ b/tree_test.go
@@ -298,7 +298,7 @@ type TestMatcher struct {
 	match bool
 }
 
-func (fm *TestMatcher) IsMatch(value interface{}) bool {
+func (fm *TestMatcher) Match(value interface{}) bool {
 	return fm.match
 }
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -34,7 +34,7 @@ func testPath(t *testing.T, tree *node, path string, expectPath string, expected
 	expectCatchAll := strings.Contains(expectPath, "/*")
 
 	t.Log("Testing", path)
-	n, paramList := tree.search(path[1:], tm)
+	n, paramList, _ := tree.search(path[1:], tm)
 	if expectPath != "" && n == nil {
 		t.Errorf("No match for %s, expected %s", path, expectPath)
 		return
@@ -298,8 +298,8 @@ type TestMatcher struct {
 	match bool
 }
 
-func (fm *TestMatcher) Match(value interface{}) bool {
-	return fm.match
+func (fm *TestMatcher) Match(value interface{}) (bool, interface{})	 {
+	return fm.match, value
 }
 
 func TestFalseMatcher(t *testing.T) {
@@ -309,7 +309,7 @@ func TestFalseMatcher(t *testing.T) {
 		t.Error(err)
 	}
 
-	v, _ := tree.LookupMatcher("/some/path", &TestMatcher{false})
+	v, _, _ := tree.LookupMatcher("/some/path", &TestMatcher{false})
 
 	if v != nil {
 		t.Error("failed, no match expected for false matcher")
@@ -323,7 +323,7 @@ func TestTrueMatcher(t *testing.T) {
 		t.Error(err)
 	}
 
-	v, _ := tree.LookupMatcher("/some/path", &TestMatcher{true})
+	v, _, _ := tree.LookupMatcher("/some/path", &TestMatcher{true})
 
 	if v == nil {
 		t.Error("failed, match expected for true matcher")

--- a/tree_test.go
+++ b/tree_test.go
@@ -34,7 +34,7 @@ func testPath(t *testing.T, tree *node, path string, expectPath string, expected
 	expectCatchAll := strings.Contains(expectPath, "/*")
 
 	t.Log("Testing", path)
-	n, paramList := tree.search(path[1:], nil)
+	n, paramList := tree.search(path[1:], tm)
 	if expectPath != "" && n == nil {
 		t.Errorf("No match for %s, expected %s", path, expectPath)
 		return
@@ -309,7 +309,7 @@ func TestFalseMatcher(t *testing.T) {
 		t.Error(err)
 	}
 
-	v, _ := tree.Lookup("/some/path", &TestMatcher{false})
+	v, _ := tree.LookupMatcher("/some/path", &TestMatcher{false})
 
 	if v != nil {
 		t.Error("failed, no match expected for false matcher")
@@ -323,7 +323,21 @@ func TestTrueMatcher(t *testing.T) {
 		t.Error(err)
 	}
 
-	v, _ := tree.Lookup("/some/path", &TestMatcher{true})
+	v, _ := tree.LookupMatcher("/some/path", &TestMatcher{true})
+
+	if v == nil {
+		t.Error("failed, match expected for true matcher")
+	}
+}
+
+func TestDefaultMatcher(t *testing.T) {
+	tree := &Tree{}
+	err := tree.Add("/some/path", 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	v, _ := tree.Lookup("/some/path")
 
 	if v == nil {
 		t.Error("failed, match expected for true matcher")
@@ -336,7 +350,7 @@ func BenchmarkTreeNullRequest(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tree.search("", nil)
+		tree.search("", tm)
 	}
 }
 
@@ -347,7 +361,7 @@ func BenchmarkTreeOneStatic(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tree.search("abc", nil)
+		tree.search("abc", tm)
 	}
 }
 
@@ -358,6 +372,6 @@ func BenchmarkTreeOneParam(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tree.search("abc", nil)
+		tree.search("abc", tm)
 	}
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -298,7 +298,7 @@ type TestMatcher struct {
 	match bool
 }
 
-func (fm *TestMatcher) isMatch(value interface{}) bool {
+func (fm *TestMatcher) IsMatch(value interface{}) bool {
 	return fm.match
 }
 


### PR DESCRIPTION
This is implementation of fix for https://github.com/zalando/skipper/issues/116

Lookup just have Matcher and when node founded, checks that it is matched by matcher.

This implementation have BC break and performance degradation.

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkTreeNullRequest-4     5.46          6.32          +15.75%
BenchmarkTreeOneStatic-4       23.9          24.7          +3.35%
BenchmarkTreeOneParam-4        21.4          23.5          +9.81%
```

I think all another implementations will have similar degradation, mostly it is related to add new argument to function signatures.